### PR TITLE
update scikit-learn version requirement from 0.17 to 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Required python libraries :
 - pandas  > 0.17.
 - numpy > 1.10.0
 - argparse > 1.2.1 
-- scikit-learn > 0.17
+- scikit-learn > 0.18
 - pymzML > 0.7.7
 
 Optional requirements :

--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ Python 2.7
 pandas  > 0.17.
 numpy > 1.9.0
 argparse > 1.2.1 
-scikit-learn > 0.17
+scikit-learn > 0.18
 
 moFF is composed by two stand alone modules : 
 	moff_mbr.py :  matching between run 


### PR DESCRIPTION
moFF_mbr uses the 'neg_mean_absolute_error' scorer in sklearn. It was renamed as such in sklearn ver 0.18.