### PR TITLE
Some path changes for conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - conda update --yes conda
+	- conda config --add channels bioconda
     - travis_retry conda create --yes -n TEST $CONDA --file ./requirements/development.txt
     - source activate TEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - conda update --yes conda
-	- conda config --add channels bioconda
+    - conda config --add channels bioconda
     - travis_retry conda create --yes -n TEST $CONDA --file ./requirements/development.txt
     - source activate TEST
 

--- a/moff.py
+++ b/moff.py
@@ -497,7 +497,7 @@ def main_apex_alone():
 	log.addHandler(ch)
 
 	config = ConfigParser.RawConfigParser()
-	config.read(os.path.join(os.path.dirname(sys.argv[0]), 'moff_setting.properties'))
+	config.read(os.path.join(os.path.realpath(os.path.dirname(sys.argv[0])), 'moff_setting.properties'))
 
 	df = pd.read_csv(file_name, sep="\t")
 	#df = df.ix[0:100,:]

--- a/moff.py
+++ b/moff.py
@@ -415,6 +415,9 @@ def apex_multithr(data_ms2,name_file, raw_name, tol, h_rt_w, s_w, s_w_match, loc
 		#log.critical('Apex module has detected mbr peptides')
 		#log.info('moff_rtWin_peak for matched peptide:   %4.4f ', s_w_match)
 
+	# assumes txic is in the same directory as moff.py
+	txic_executable_name="txic_json.exe"
+	txic_path = os.path.join(os.path.realpath(os.path.dirname(sys.argv[0])), txic_executable_name)
 
 	## to export a list of XIc
 	try:
@@ -428,9 +431,9 @@ def apex_multithr(data_ms2,name_file, raw_name, tol, h_rt_w, s_w, s_w_match, loc
 		if not flag_mzml :
 			# txic-28-9-separate-jsonlines.exe
 			if not flag_windows:
-				args_txic = shlex.split( "mono txic_json.exe " +  " -j " + temp.to_json( orient='records' ) + " -f " + loc,posix=True )
+				args_txic = shlex.split( "mono " + txic_path + " -j " + temp.to_json( orient='records' ) + " -f " + loc,posix=True )
 			else:
-				args_txic = shlex.split("txic_json.exe " + " -j " + temp.to_json(orient='records') + " -f " + loc, posix=False)
+				args_txic = shlex.split(txic_path + " -j " + temp.to_json(orient='records') + " -f " + loc, posix=False)
 			start_timelocal = time.time()
 			p = subprocess.Popen(args_txic, stdout=subprocess.PIPE)
 			output, err = p.communicate()

--- a/moff.py
+++ b/moff.py
@@ -17,7 +17,6 @@ import multiprocessing
 import simplejson as json
 import traceback
 import pymzml
-
 import numpy as np
 import pandas as pd
 
@@ -415,9 +414,9 @@ def apex_multithr(data_ms2,name_file, raw_name, tol, h_rt_w, s_w, s_w_match, loc
 		#log.critical('Apex module has detected mbr peptides')
 		#log.info('moff_rtWin_peak for matched peptide:   %4.4f ', s_w_match)
 
-	# assumes txic is in the same directory as moff.py
+	# get txic path: assumes txic is in the same directory as moff.py
 	txic_executable_name="txic_json.exe"
-	txic_path = os.path.join(os.path.realpath(os.path.dirname(sys.argv[0])), txic_executable_name)
+	txic_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), txic_executable_name)
 
 	## to export a list of XIc
 	try:
@@ -500,7 +499,7 @@ def main_apex_alone():
 	log.addHandler(ch)
 
 	config = ConfigParser.RawConfigParser()
-	config.read(os.path.join(os.path.realpath(os.path.dirname(sys.argv[0])), 'moff_setting.properties'))
+	config.read(os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'moff_setting.properties'))
 
 	df = pd.read_csv(file_name, sep="\t")
 	#df = df.ix[0:100,:]

--- a/moff_mbr.py
+++ b/moff_mbr.py
@@ -128,7 +128,7 @@ def run_mbr(args):
     w_mbr.setLevel(logging.INFO)
     log.addHandler(w_mbr)
 
-    moff_path = os.path.dirname(sys.argv[0])
+    moff_path = os.path.realpath(os.path.dirname(sys.argv[0]))
     config = ConfigParser.RawConfigParser()
     config.read(os.path.join(moff_path, 'moff_setting.properties'))
 

--- a/moff_mbr.py
+++ b/moff_mbr.py
@@ -128,7 +128,7 @@ def run_mbr(args):
     w_mbr.setLevel(logging.INFO)
     log.addHandler(w_mbr)
 
-    moff_path = os.path.realpath(os.path.dirname(sys.argv[0]))
+    moff_path = os.path.dirname(os.path.realpath(sys.argv[0]))
     config = ConfigParser.RawConfigParser()
     config.read(os.path.join(moff_path, 'moff_setting.properties'))
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 scikit-learn
 pandas
+simplejson

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,3 +4,4 @@ scipy
 scikit-learn
 pandas
 simplejson
+pymzml


### PR DESCRIPTION
Hi, 

I'm working on writing a conda recipe for moFF, for ease of distribution and so we can later incorporate it into Galaxy. Because conda uses some symbolic links, I added `os.path.realpath` to a few paths, so that the symlinks are followed to the target. I don't think this should affect usage outside of conda. 

I also added `simplejson` and `pymzml` to `requirements/development.txt` and then added the `bioconda` channel in `.travis.yml`, which is the only way I could get moFF to build on Travis (I think `pymzml` is only in `bioconda`. 

Anyway, let me know what you think!